### PR TITLE
Fix copyright symbol encoding issue in footer

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
         if (footers.length > 0) {
             const rightsText = footerConfig.allRightsReserved ? ' All rights reserved.' : '';
             footers.forEach(footer => {
-                footer.textContent = `© ${footerConfig.copyrightYear} ${footerConfig.companyName}.${rightsText}`;
+                footer.innerHTML = `&copy; ${footerConfig.copyrightYear} ${footerConfig.companyName}.${rightsText}`;
             });
         }
     }


### PR DESCRIPTION
- Replace problematic © character with &copy; HTML entity
- Use innerHTML instead of textContent to properly render HTML entities
- Resolves 'Â©' encoding artifact in footer display