### PR TITLE
fix: improve auto-fix trigger using @copilot

### DIFF
--- a/.github/workflows/apply-auto-fixes.yml
+++ b/.github/workflows/apply-auto-fixes.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@github-actions apply-auto-fixes'))
+       contains(github.event.comment.body, '@copilot apply-auto-fixes'))
     
     steps:
       - name: Checkout Repository

--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -203,7 +203,7 @@ jobs:
             // Handle click
           };
           ```
-          🤖 **Auto-fix available**: Comment `@github-actions apply-auto-fixes` to automatically apply these changes.
+          🤖 **Auto-fix available**: Comment `@copilot apply-auto-fixes` to automatically apply these changes.
           
           EOF
           fi
@@ -292,9 +292,9 @@ jobs:
             echo "" >> auto-fix-preview.md
             echo "### 🚀 How to Apply" >> auto-fix-preview.md
             echo "To apply these fixes:" >> auto-fix-preview.md
-            echo "1. **Comment**: \`@github-actions apply-auto-fixes\` on this PR" >> auto-fix-preview.md
-            echo "2. **Manual**: Copy the changes above to your local branch" >> auto-fix-preview.md
-            echo "3. **Workflow**: Run the \"Apply Auto-fixes\" workflow manually from the Actions tab" >> auto-fix-preview.md
+            echo "1. **Comment**: \`@copilot apply-auto-fixes\` on this PR" >> auto-fix-preview.md
+            echo "2. **Actions Tab**: Go to Actions → \"Apply Auto-fixes\" → Run workflow (enter PR number)" >> auto-fix-preview.md
+            echo "3. **Manual**: Copy the changes above to your local branch" >> auto-fix-preview.md
             
             echo "auto_fixes_prepared=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Improves the auto-fix workflow trigger mechanism:

🔧 **Changes:**
- Use `@copilot apply-auto-fixes` instead of `@github-actions apply-auto-fixes`
- @copilot is a real GitHub user that exists in repos with Copilot enabled
- More reliable than the previous non-existent @github-actions user

📋 **Why this works better:**
- @copilot actually exists as a GitHub user
- GitHub can properly handle the mention/notification
- Should trigger the workflow more reliably

🧪 **Testing:**
Once merged, test on PR #105 by commenting `@copilot apply-auto-fixes`